### PR TITLE
Add multiple dark mode themes feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,6 +191,18 @@
         </div>
 
         <div class="setting-group">
+          <h4>Theme Settings</h4>
+    <div class="setting-item">
+        <label for="themeSelect">Theme:</label>
+        <select id="themeSelect" class="setting-input">
+            <option value="light">Light</option>
+            <option value="dark">Dark (Default)</option>
+            <option value="dark-blue">Dark Blue</option>
+            <option value="dark-purple">Dark Purple</option>
+            <option value="dark-green">Dark Green</option>
+            <option value="high-contrast">High Contrast</option>
+        </select>
+    </div>
           <h4>Custom Links</h4>
           <div class="setting-item">
             <button class="add-link-btn" id="addLinkBtn">Add New Link</button>

--- a/startpage/languages.js
+++ b/startpage/languages.js
@@ -1,6 +1,15 @@
 // Language translations for SyrianZone Startpage
 const languages = {
     ar: {
+        themeSettings: "إعدادات السمة",
+        themes: {
+        light: "فاتح",
+         dark: "داكن (افتراضي)",
+        "dark-blue": "أزرق داكن",
+        "dark-purple": "بنفسجي داكن",
+        "dark-green": "أخضر داكن",
+        "high-contrast": "تباين عالي"
+        },
         // Search Section
         searchPlaceholder: "ابحث في الويب...",
         searchButton: "بحث",
@@ -104,6 +113,16 @@ const languages = {
     },
     
     en: {
+
+        themeSettings: "Theme Settings",
+            themes: {
+                light: "Light",
+                dark: "Dark (Default)",
+                "dark-blue": "Dark Blue",
+                "dark-purple": "Dark Purple",
+                "dark-green": "Dark Green",
+                "high-contrast": "High Contrast"
+            },
         // Search Section
         searchPlaceholder: "Search the web...",
         searchButton: "Search",

--- a/startpage/script.js
+++ b/startpage/script.js
@@ -50,18 +50,37 @@ class Startpage {
         this.updateThemeIcon();
     }
 
-    toggleTheme() {
-        this.settings.theme = this.settings.theme === 'light' ? 'dark' : 'light';
-        this.applyTheme();
-        this.saveSettings();
+    cycleTheme() {
+    const themes = ['light', 'dark', 'dark-blue', 'dark-purple', 'dark-green', 'high-contrast'];
+    const currentIndex = themes.indexOf(this.settings.theme);
+    const nextIndex = (currentIndex + 1) % themes.length;
+    this.settings.theme = themes[nextIndex];
+    this.applyTheme();
+    this.saveSettings();
     }
 
-    updateThemeIcon() {
-        const themeIcon = document.querySelector('.theme-icon');
-        if (themeIcon) {
-            themeIcon.textContent = this.settings.theme === 'light' ? '🌙' : '☀️';
-        }
+    setTheme(theme) {
+    this.settings.theme = theme;
+    this.applyTheme();
+    this.saveSettings();
     }
+
+
+
+    updateThemeIcon() {
+    const themeIcon = document.querySelector('.theme-icon');
+    if (themeIcon) {
+        const icons = {
+            'light': '☀️',
+            'dark': '🌙',
+            'dark-blue': '💙',
+            'dark-purple': '💜',
+            'dark-green': '💚',
+            'high-contrast': '⚡'
+        };
+        themeIcon.textContent = icons[this.settings.theme] || '🌙';
+    }
+}
 
     // Language Management
     applyLanguage() {
@@ -223,6 +242,21 @@ class Startpage {
     }
 
     translateSettingsPanel(lang) {
+        const themeSettingsTitle = document.querySelector('.setting-group h4');
+        if (themeSettingsTitle && themeSettingsTitle.textContent.includes('Theme')) {
+            themeSettingsTitle.textContent = lang.themeSettings;
+        }
+
+        const themeSelect = document.getElementById('themeSelect');
+        if (themeSelect) {
+            const options = themeSelect.options;
+            for (let i = 0; i < options.length; i++) {
+                const value = options[i].value;
+                if (lang.themes[value]) {
+                    options[i].textContent = lang.themes[value];
+                }
+            }
+        }
         // Update settings panel titles
         const settingsTitle = document.querySelector('.settings-header h3');
         if (settingsTitle) {
@@ -766,6 +800,10 @@ async fetchWeather() {
         const governorate = document.getElementById('governorate');
         const latitude = document.getElementById('latitude');
         const longitude = document.getElementById('longitude');
+        const themeSelect = document.getElementById('themeSelect');
+        if (themeSelect) {
+        themeSelect.value = this.settings.theme;
+        }
         
         if (locationType) locationType.value = this.settings.weather.locationType;
         if (governorate) governorate.value = this.settings.weather.governorate;
@@ -911,7 +949,7 @@ async fetchWeather() {
         // Theme toggle
         const themeToggle = document.getElementById('themeToggle');
         if (themeToggle) {
-            themeToggle.addEventListener('click', () => this.toggleTheme());
+        themeToggle.addEventListener('click', () => this.cycleTheme());
         }
 
         // Search form
@@ -936,6 +974,13 @@ async fetchWeather() {
         if (closeSettings) {
             closeSettings.addEventListener('click', () => this.closeSettings());
         }
+
+        const themeSelect = document.getElementById('themeSelect');
+        if (themeSelect) {
+        themeSelect.addEventListener('change', (e) => {
+        this.setTheme(e.target.value);
+        });
+}
 
         // About modal controls
         const closeAboutModal = document.getElementById('closeAboutModal');

--- a/startpage/style.css
+++ b/startpage/style.css
@@ -49,6 +49,67 @@
     --shadow-hover: 0 4px 20px rgba(0, 0, 0, 0.4);
 }
 
+/* Additional Dark Themes */
+[data-theme="dark-blue"] {
+    --bg-primary: #0a0e1a;
+    --bg-secondary: #141824;
+    --bg-tertiary: #1e2230;
+    --text-primary: #e8eaed;
+    --text-secondary: #9aa0a6;
+    --accent-color: #4285f4;
+    --accent-hover: #1a73e8;
+    --secondary-color: #ea4335;
+    --secondary-hover: #d33b27;
+    --border-color: #2a2e3c;
+    --shadow: 0 2px 10px rgba(0, 0, 0, 0.4);
+    --shadow-hover: 0 4px 20px rgba(66, 133, 244, 0.3);
+}
+
+[data-theme="dark-purple"] {
+    --bg-primary: #0d0a14;
+    --bg-secondary: #1a1523;
+    --bg-tertiary: #261f33;
+    --text-primary: #e9e4f0;
+    --text-secondary: #b5a7c6;
+    --accent-color: #9c27b0;
+    --accent-hover: #7b1fa2;
+    --secondary-color: #ff6f00;
+    --secondary-hover: #e65100;
+    --border-color: #332b42;
+    --shadow: 0 2px 10px rgba(0, 0, 0, 0.4);
+    --shadow-hover: 0 4px 20px rgba(156, 39, 176, 0.3);
+}
+
+[data-theme="dark-green"] {
+    --bg-primary: #0a0f0a;
+    --bg-secondary: #141a14;
+    --bg-tertiary: #1e261e;
+    --text-primary: #e4f0e4;
+    --text-secondary: #a7c6a7;
+    --accent-color: #4caf50;
+    --accent-hover: #388e3c;
+    --secondary-color: #ff9800;
+    --secondary-hover: #f57c00;
+    --border-color: #2b3c2b;
+    --shadow: 0 2px 10px rgba(0, 0, 0, 0.4);
+    --shadow-hover: 0 4px 20px rgba(76, 175, 80, 0.3);
+}
+
+[data-theme="high-contrast"] {
+    --bg-primary: #000000;
+    --bg-secondary: #0a0a0a;
+    --bg-tertiary: #1a1a1a;
+    --text-primary: #ffffff;
+    --text-secondary: #cccccc;
+    --accent-color: #00ff00;
+    --accent-hover: #00cc00;
+    --secondary-color: #ff00ff;
+    --secondary-hover: #cc00cc;
+    --border-color: #333333;
+    --shadow: 0 2px 10px rgba(0, 255, 0, 0.2);
+    --shadow-hover: 0 4px 20px rgba(0, 255, 0, 0.4);
+}
+
 /* Language-specific Font Rules */
 html[lang="en"] body,
 html[lang="en"] h1,


### PR DESCRIPTION
Changes

Added 5 theme variants: Dark (default), Dark Blue, Dark Purple, Dark Green, and High Contrast
Theme selector in settings: Users can choose themes from a dropdown menu
Cycle through themes: Theme toggle button now cycles through all available themes
Localization support: Added Arabic and English translations for theme names
Persistent selection: Theme preference is saved to localStorage

Theme Options

Light - Original light theme
Dark - Default dark theme with Syrian brand colors
Dark Blue - Blue accent variant for dark mode
Dark Purple - Purple accent variant for dark mode
Dark Green - Green accent variant for dark mode
High Contrast - Accessibility-focused theme with maximum contrast

Technical Details

CSS custom properties for each theme variant
Updated cycleTheme() method to rotate through all themes
New setTheme() method for direct theme selection
Theme icons update to reflect current selection (🌙💙💜💚⚡)