### PR TITLE
startpage clock added

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,14 +51,27 @@
         <button class="settings-btn" id="settingsBtn">⚙️</button>
       </div>
     </div>
-    <!-- Weather Widget -->
-    <section class="weather-section">
-      <div class="weather-container">
-        <div class="weather-content" id="weatherContent">
-          <div class="weather-loading">Loading weather...</div>
+        <!-- Wrapper for Weather and Clock -->
+    <div class="top-info-wrapper">
+      <!-- Weather Widget -->
+      <section class="weather-section">
+        <div class="weather-container">
+          <div class="weather-content" id="weatherContent">
+            <div class="weather-loading">Loading weather...</div>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
+
+      <!-- Clock Section -->
+      <section class="clock-section">
+        <div class="clock-container">
+            <div class="clock-display" id="clockDisplay">
+                <span class="clock-time" id="clockTime">--:--:--</span>
+                <span class="clock-date" id="clockDate"></span>
+            </div>
+        </div>
+      </section>
+    </div>
     <!-- Logo Section -->
     <section class="logo-section">
       <div class="logo-container">
@@ -165,6 +178,16 @@
               <option value="coordinates">Custom Coordinates</option>
             </select>
           </div>
+          <div class="setting-group">
+    <h4>Clock Settings</h4>
+    <div class="setting-item">
+        <label for="clockFormat">Time Format:</label>
+        <select id="clockFormat" class="setting-input">
+            <option value="12">12 Hour</option>
+            <option value="24">24 Hour</option>
+        </select>
+    </div>
+</div>
           <div class="setting-item" id="governorateSetting">
             <label for="governorate">Governorate:</label>
             <select id="governorate" class="setting-input">

--- a/startpage/languages.js
+++ b/startpage/languages.js
@@ -47,6 +47,11 @@ const languages = {
             "fog": "ضباب كثيف",
             "haze": "ضباب خفيف"
         },
+
+        clockSettings: "إعدادات الساعة",
+        timeFormat: "تنسيق الوقت:",
+        format12: "12 ساعة",
+        format24: "24 ساعة",
         
         // Links Section
         quickLinks: "روابط سريعة",
@@ -160,6 +165,11 @@ const languages = {
             "fog": "fog",
             "haze": "haze"
         },
+
+        clockSettings: "Clock Settings",
+        timeFormat: "Time Format:",
+        format12: "12 Hour",
+        format24: "24 Hour",
         
         // Links Section
         quickLinks: "Quick Links",

--- a/startpage/script.js
+++ b/startpage/script.js
@@ -14,6 +14,7 @@ class Startpage {
         this.loadCustomLinks();
         this.updateWeatherDisplay();
         this.setupSearchEngine();
+        this.initClock();
     }
 
     // Settings Management
@@ -31,6 +32,7 @@ class Startpage {
                     lon: 36.2765
                 }
             },
+            clockFormat: '12',
             customLinks: {
                 row1: []
             }
@@ -66,6 +68,41 @@ class Startpage {
     }
 
 
+    initClock() {
+    this.updateClock();
+    setInterval(() => this.updateClock(), 1000);
+}
+
+updateClock() {
+    const now = new Date();
+    const timeElement = document.getElementById('clockTime');
+    const dateElement = document.getElementById('clockDate');
+    
+    if (!timeElement || !dateElement) return;
+    
+    let hours = now.getHours();
+    let minutes = now.getMinutes();
+    let period = '';
+    
+    if (this.settings.clockFormat === '12') {
+        period = hours >= 12 ? ' PM' : ' AM';
+        hours = hours % 12 || 12;
+    }
+    
+    hours = hours.toString().padStart(2, '0');
+    minutes = minutes.toString().padStart(2, '0');    
+    timeElement.textContent = `${hours}:${minutes}${period}`;
+    
+    const dateOptions = {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric'
+    };
+    
+    const locale = this.currentLanguage === 'ar' ? 'ar-SY' : 'en-US';
+    dateElement.textContent = now.toLocaleDateString(locale, dateOptions);
+}
 
     updateThemeIcon() {
     const themeIcon = document.querySelector('.theme-icon');
@@ -257,6 +294,23 @@ class Startpage {
                 }
             }
         }
+
+         const clockSettingsTitle = Array.from(document.querySelectorAll('.setting-group h4'))
+        .find(el => el.textContent.includes('Clock'));
+    if (clockSettingsTitle) {
+        clockSettingsTitle.textContent = lang.clockSettings;
+    }
+    
+    const clockFormatLabel = document.querySelector('label[for="clockFormat"]');
+    if (clockFormatLabel) {
+        clockFormatLabel.textContent = lang.timeFormat;
+    }
+    
+    const clockFormatSelect = document.getElementById('clockFormat');
+    if (clockFormatSelect) {
+        clockFormatSelect.options[0].textContent = lang.format12;
+        clockFormatSelect.options[1].textContent = lang.format24;
+    }
         // Update settings panel titles
         const settingsTitle = document.querySelector('.settings-header h3');
         if (settingsTitle) {
@@ -801,6 +855,10 @@ async fetchWeather() {
         const latitude = document.getElementById('latitude');
         const longitude = document.getElementById('longitude');
         const themeSelect = document.getElementById('themeSelect');
+        const clockFormat = document.getElementById('clockFormat');
+        if (clockFormat) {
+        clockFormat.value = this.settings.clockFormat;
+        }
         if (themeSelect) {
         themeSelect.value = this.settings.theme;
         }
@@ -937,6 +995,16 @@ async fetchWeather() {
         } else {
             console.error('About button not found');
         }
+
+        const clockFormat = document.getElementById('clockFormat');
+        if (clockFormat) {
+        clockFormat.value = this.settings.clockFormat;
+        clockFormat.addEventListener('change', (e) => {
+            this.settings.clockFormat = e.target.value;
+            this.saveSettings();
+            this.updateClock(); 
+        });
+    }
 
 
 

--- a/startpage/style.css
+++ b/startpage/style.css
@@ -399,12 +399,22 @@ body[dir="rtl"] .search-form {
     box-shadow: var(--shadow-hover);
 }
 
+.top-info-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 40px; 
+    flex-wrap: wrap; 
+    width: 100%;
+    margin-bottom: 20px;
+}
+
 /* Weather Section - Above search, centered */
 .weather-section {
     display: flex;
     justify-content: center;
-    margin-bottom: 40px;
-    width: 100%;
+    margin-bottom: 0;
+    width: auto;
 }
 
 .weather-container {
@@ -471,6 +481,51 @@ body[dir="rtl"] .search-form {
 .weather-detail-value {
     font-weight: 600;
     color: var(--text-primary);
+}
+
+/* Clock Section */
+.clock-section {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 0;
+    width: auto;
+}
+
+.clock-container {
+    text-align: center;
+    padding: 15px;
+}
+
+.clock-display {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 5px;
+}
+
+.clock-time {
+    font-size: 3rem;
+    font-weight: 700;
+    color: var(--accent-color);
+    letter-spacing: 0.05em;
+    font-variant-numeric: tabular-nums;
+}
+
+.clock-date {
+    font-size: 1rem;
+    color: var(--text-secondary);
+}
+
+@media (max-width: 768px) {
+    .clock-time {
+        font-size: 2.5rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .clock-time {
+        font-size: 2rem;
+    }
 }
 
 /* Links Section - Simplified Design */


### PR DESCRIPTION
This PR introduces clock widget to the startpage and refines the header layout by positioning it side-by-side with the weather widget for a more organized look.

Key Changes:

-New Clock Widget: A live-updating clock and date display has been added to the main view.

-Configurable Time Format: Users can now choose between a 12-hour or 24-hour time format from a new "Clock Settings" section 
in the settings panel. This preference is saved locally.

-Improved Header Layout: The new clock and the existing weather widget are now wrapped in a flex container, aligning them horizontally on wider screens.

-Internationalization: The date format and all new settings labels are fully translated for both English and Arabic.